### PR TITLE
Fixed file handle leak

### DIFF
--- a/lib/exempi/consts.rb
+++ b/lib/exempi/consts.rb
@@ -263,7 +263,7 @@ module Exempi
       end
       struct[:nanoSecond] = source.to_time.nsec
 
-      match = source.zone.match /(?<sign>[-+]){1}(?<hour>\d\d){1}:(?<minute>\d\d){1}/
+      match = source.zone.match(/(?<sign>[-+]){1}(?<hour>\d\d){1}:(?<minute>\d\d){1}/)
       if match
         if match[:sign] == '-' then struct[:tzSign] = -1
         elsif match[:hour] == '00' && match[:minute] == '00' then struct[:tzSign] = 0

--- a/lib/exempi/exempi.rb
+++ b/lib/exempi/exempi.rb
@@ -45,10 +45,10 @@ module Exempi
 
   # we redefine attach_function so we can wrap all of the C functions
   class << self
-    def verbose?; @verbose; end
-    attr_writer :verbose
+    attr_accessor :verbose
+    alias_method :verbose?, :verbose
 
-    def attach_function name, func, args, returns=nil, options={}
+    def attach_function(name, func, arguments, returns=nil, options={})
       super
       old_method = method(name)
       define_singleton_method(name) do |*args|

--- a/lib/exempi/exempi.rb
+++ b/lib/exempi/exempi.rb
@@ -61,14 +61,17 @@ module Exempi
     # Exempi spews stderr all over the place without giving you any way
     # to quiet it! Boo!
     def shutup!
-      if not verbose?
+      unless verbose?
         io = IO.new 2
         stderr = io.dup
         io.reopen IO::NULL
       end
       yield
     ensure
-      io.reopen stderr unless verbose?
+      unless verbose?
+        io.reopen stderr
+        stderr.close
+      end
     end
   end
 


### PR DESCRIPTION
The `shutup!` method to silence calls to the `exempi` library did not close its file handles. I fixed the leak in commit 55e5386 and also got rid of some ruby warnings in e332926.

thanks,
Steve
