### PR TITLE
Replace Fixnum with Integer

### DIFF
--- a/lib/exempi/consts.rb
+++ b/lib/exempi/consts.rb
@@ -297,7 +297,7 @@ module Exempi
             else
               val
             end
-          when Fixnum then values
+          when Integer then values
           when NilClass then 0
           else
             invalid_opt = values.find {|v| Exempi.const_get(@enum)[v].nil?}


### PR DESCRIPTION
Hi 👋 ,

this makes the gem work on Ruby >= 3.2. Fixnum was [deprecated in 2.4/2.7][1] and finally [removed with Ruby 3.2][2]

[1]: https://bugs.ruby-lang.org/issues/12739
[2]: https://github.com/ruby/ruby/commit/40e7aefe