### PR TITLE
Add minitest to gemspec, fix deprecation warnings

### DIFF
--- a/exempi.gemspec
+++ b/exempi.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ffi', '>= 1.1.5'
 
   gem.add_development_dependency 'rake', '>= 0.9.2.2'
+  gem.add_development_dependency 'minitest', '~> 5.0'
 end

--- a/test/dataconverter_test.rb
+++ b/test/dataconverter_test.rb
@@ -4,45 +4,45 @@ require 'minitest/autorun'
 
 describe "dataconverter helper" do
 	it "should be able to look up single symbol values" do
-    Exempi::XmpOpenFileOptions.to_native(:XMP_OPEN_READ, nil).must_equal 0x00000001
+    _(Exempi::XmpOpenFileOptions.to_native(:XMP_OPEN_READ, nil)).must_equal 0x00000001
   end
 
   it "should be able to look up an array of symbol values" do
-    Exempi::XmpOpenFileOptions.to_native([:XMP_OPEN_USESMARTHANDLER,
-      :XMP_OPEN_USEPACKETSCANNING], nil).must_equal 0x00000060
+    _(Exempi::XmpOpenFileOptions.to_native([:XMP_OPEN_USESMARTHANDLER,
+      :XMP_OPEN_USEPACKETSCANNING], nil)).must_equal 0x00000060
   end
 
   it "should be able to handle pure integer values" do
-    Exempi::XmpOpenFileOptions.to_native(0x00000001, nil).must_equal 0x00000001
+    _(Exempi::XmpOpenFileOptions.to_native(0x00000001, nil)).must_equal 0x00000001
   end
 
   it "should return 0 when nil is passed" do
-    Exempi::XmpOpenFileOptions.to_native(nil, nil).must_equal 0
+    _(Exempi::XmpOpenFileOptions.to_native(nil, nil)).must_equal 0
   end
 
   it "should raise when invalid options are passed" do
-    lambda do
+    _{
       Exempi::XmpOpenFileOptions.to_native(:notanoption, nil)
-    end.must_raise Exempi::InvalidOptionError
+    }.must_raise Exempi::InvalidOptionError
 
-    lambda do
+    _{
       Exempi::XmpOpenFileOptions.to_native([:notanoption, :notanoption], nil)
-    end.must_raise Exempi::InvalidOptionError
+    }.must_raise Exempi::InvalidOptionError
   end
 
   it "should be able to translate integers into hashes of options" do
     hash = Exempi.parse_bitmask 0x00000060, Exempi::XMP_OPEN_FILE_OPTIONS
 
-    assert hash[:XMP_OPEN_USESMARTHANDLER]
-    assert hash[:XMP_OPEN_USEPACKETSCANNING]
-    refute hash[:XMP_OPEN_FORUPDATE]
+    _(hash[:XMP_OPEN_USESMARTHANDLER]).must_equal true
+    _(hash[:XMP_OPEN_USEPACKETSCANNING]).must_equal true
+    _(hash[:XMP_OPEN_FORUPDATE]).must_equal false
   end
 
   it "should optionally be able to return short option names" do
     hash = Exempi.parse_bitmask 0x00000060, Exempi::XMP_OPEN_FILE_OPTIONS, true
 
-    assert hash[:usesmarthandler]
-    assert hash[:usepacketscanning]
-    refute hash[:forupdate]
+    _(hash[:usesmarthandler]).must_equal true
+    _(hash[:usepacketscanning]).must_equal true
+    _(hash[:forupdate]).must_equal false
   end
 end

--- a/test/datetime_test.rb
+++ b/test/datetime_test.rb
@@ -14,22 +14,22 @@ describe "DateTime struct wrapper" do
     today = DateTime.now
     date = Exempi::XmpDateTime.from_datetime today
 
-    date[:year].must_equal today.year
+    _(date[:year]).must_equal today.year
   end
 
   it "should be able to create an XmpDateTime struct from a string" do
     today = '2012-09-07'
     date = Exempi::XmpDateTime.from_datetime today
 
-    date[:year].must_equal 2012
-    date[:month].must_equal 9
-    date[:day].must_equal 7
+    _(date[:year]).must_equal 2012
+    _(date[:month]).must_equal 9
+    _(date[:day]).must_equal 7
   end
 
   it "should be able to translate XmpDateTime structs into DateTime objects" do
     today = DateTime.now
     date = Exempi::XmpDateTime.from_datetime today
 
-    date.to_datetime.must_equal today
+    _(date.to_datetime).must_equal today
   end
 end

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -5,18 +5,18 @@ require 'minitest/autorun'
 describe "Exempi helpers" do
   it "should be able to silence stderr for noisy blocks" do
     Exempi.verbose = false
-    lambda do
+    _{
       Exempi.send(:shutup!) { STDERR.puts "You should not see this" }
-    end.must_be_silent
+    }.must_be_silent
   end
 
   it "should wrap Exempi functions correctly" do
     Exempi.verbose = false
-    lambda do
+    _{
       # Exempi spews errors to stderr, so we've wrapped attach_function
       # in order to ensure that every function call is wrapped with
       # the silencing shutup! method
       Exempi.xmp_files_open_new('no_file_here', 0)
-    end.must_be_silent
+    }.must_be_silent
   end
 end


### PR DESCRIPTION
Hello again 😄 

Without minitest in the gemspec running `rake test` failed with `test/dataconverter_test.rb:3:in `require': cannot load such file -- minitest/autorun`.

After installing the current version it complained about deprecation warnings:

```
DEPRECATED: global use of must_equal from /Users/dominik/code/ruby/exempi/test/datetime_test.rb:17. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_raise from /Users/dominik/code/ruby/exempi/test/dataconverter_test.rb:24. Use _{obj.method}.must_raise instead. This will fail in Minitest 6.
```

This addresses both problems.